### PR TITLE
fix(babelHelpersIssue): Adding on Rollup an option to use a runtimeHelper

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,8 @@ export default {
     babel({
       exclude: 'node_modules/**',
       plugins: [ '@babel/external-helpers' ],
-      externalHelpers: true
+      externalHelpers: true,
+      runtimeHelpers: true
     }),
     resolve(),
     commonjs()


### PR DESCRIPTION
## Changes
- Setting as true and option into rollup.config that allows babel to use runtime helpers 
* This was needed because we are now setting as a plugin of babel the `@babel/plugin-transform-runtime` 