### PR TITLE
Studylist - fixing pagination and studyInstanceUid field

### DIFF
--- a/example/public/index.html
+++ b/example/public/index.html
@@ -11,7 +11,7 @@
 
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
   </head>
 
   <body>

--- a/example/src/StudyListExample.js
+++ b/example/src/StudyListExample.js
@@ -7,7 +7,7 @@ class StudyListExample extends Component {
         super(props)
 
         this.defaultStudies = [{
-            studyInstanceUID: '11111.111111.111111.11111',
+            studyInstanceUid: '11111.111111.111111.11111',
             patientName: 'John Doe',
             patientId: '1',
             accessionNumber: '1234567',
@@ -16,24 +16,24 @@ class StudyListExample extends Component {
             studyDescription: 'BRAIN',
         },
         {
-            studyInstanceUID: '2222.222222.22222.22222',
+            studyInstanceUid: '2222.222222.22222.22222',
             patientName: 'José Silva',
             patientId: '2',
             accessionNumber: '7654321',
-            studyDate:  moment().format('YYYYMMDD'),
+            studyDate: moment().format('YYYYMMDD'),
             modalities: 'CT',
             studyDescription: 'PET CT STANDARD',
         },
         {
-            studyInstanceUID: '3333.333333.33333.33333',
+            studyInstanceUid: '3333.333333.33333.33333',
             patientName: 'Antônio Jefferson',
             patientId: '3',
             accessionNumber: '732311',
-            studyDate:  moment().subtract(14, 'days').format('YYYYMMDD'),
+            studyDate: moment().subtract(14, 'days').format('YYYYMMDD'),
             modalities: 'US',
             studyDescription: '0',
         }, {
-            studyInstanceUID: '444444.44444.44444.4444',
+            studyInstanceUid: '444444.44444.44444.4444',
             patientName: 'Antonio da Silva',
             patientId: '4',
             accessionNumber: '732311',
@@ -41,7 +41,7 @@ class StudyListExample extends Component {
             modalities: 'US',
             studyDescription: '0',
         }, {
-            studyInstanceUID: '55555.55555.55555.55555',
+            studyInstanceUid: '55555.55555.55555.55555',
             patientName: 'Bezerra Souza',
             patientId: '5',
             accessionNumber: '5134543',
@@ -49,7 +49,7 @@ class StudyListExample extends Component {
             modalities: 'US',
             studyDescription: '0',
         }, {
-            studyInstanceUID: '66666.66666.66666.6666',
+            studyInstanceUid: '66666.66666.66666.6666',
             patientName: 'Geraldo Roger',
             patientId: '6',
             accessionNumber: '5315135',
@@ -68,10 +68,12 @@ class StudyListExample extends Component {
 
         this.state = {
             searchData: {},
-            studies: this.defaultStudies.slice(0, this.rowsPerPage).filter(study=>{
+            studies: this.defaultStudies.filter(study => {
                 const studyDate = moment(study['studyDate'], 'YYYYMMDD');
-                return studyDate.isBetween(moment().subtract(this.studyListDateFilterNumDays, 'days'), moment(), 'days', '[]');
-            }),
+                const startDate = moment().subtract(this.studyListDateFilterNumDays, 'days');
+                const endDate = moment();
+                return studyDate.isBetween(startDate, endDate, 'days', '[]');
+            }).slice(0, this.rowsPerPage),
         }
 
         this.onSearch = this.onSearch.bind(this);
@@ -81,12 +83,12 @@ class StudyListExample extends Component {
         alert('Import study mock ' + event);
     }
 
-    onSelectItem(studyInstanceUID) {
-        alert(studyInstanceUID + ' has selected! Now you can open your study.');
+    onSelectItem(studyInstanceUid) {
+        alert(studyInstanceUid + ' has selected! Now you can open your study.');
     }
 
     onSearch(searchData) {
-        this.setState({searchData});
+        this.setState({ searchData });
 
         const filter = (key, searchData, study) => {
             if (key === 'studyDateFrom' && searchData[key] && study['studyDate']) {
@@ -104,9 +106,9 @@ class StudyListExample extends Component {
         // just a example of local filtering
         let filteredStudies = this.defaultStudies.filter(function (study) {
             const all = ['patientName', 'patientId', 'accessionNumber', 'modalities', 'studyDescription', 'studyDateFrom',]
-            .every(key => {
-                return filter(key, searchData, study);
-            });
+                .every(key => {
+                    return filter(key, searchData, study);
+                });
 
             return all;
         }).sort(function (a, b) {
@@ -151,7 +153,7 @@ class StudyListExample extends Component {
                 }>
                     <div className="col-xs-12" style={{ padding: 0 }}>
                         <StudyList studies={this.state.studies}
-                            studyCount={this.defaultStudies.length}
+                            pageOptions={[1, 2, 3, 5, 10, 15, 20, 25, 50, 100]}
                             studyListFunctionsEnabled={true}
                             onImport={this.onImport}
                             onSelectItem={this.onSelectItem}

--- a/src/basic/paginationArea/PaginationArea.js
+++ b/src/basic/paginationArea/PaginationArea.js
@@ -6,18 +6,17 @@ class PaginationArea extends PureComponent {
   static defaultProps = {
     pageOptions: [5, 10, 25, 50, 100],
     rowsPerPage: 25,
-    currentPage: 0,
-    numberOfPages: 1
+    currentPage: 0
   };
 
   static propTypes = {
     pageOptions: PropTypes.array.isRequired,
     rowsPerPage: PropTypes.number.isRequired,
     currentPage: PropTypes.number.isRequired,
-    numberOfPages: PropTypes.number.isRequired,
     nextPageFunc: PropTypes.func,
     prevPageFunc: PropTypes.func,
-    onRowsPerPageChange: PropTypes.func
+    onRowsPerPageChange: PropTypes.func,
+    recordCount: PropTypes.number.isRequired
   };
 
   nextPage = () => {
@@ -51,7 +50,8 @@ class PaginationArea extends PureComponent {
                 <button
                   onClick={this.nextPage}
                   disabled={
-                    this.props.currentPage === this.props.numberOfPages - 1
+                    this.props.recordCount === 0 ||
+                    this.props.rowsPerPage > this.props.recordCount
                   }
                   className="btn page-link"
                 >

--- a/src/studyList/StudyList.js
+++ b/src/studyList/StudyList.js
@@ -19,7 +19,6 @@ export default class StudyList extends Component {
     studies: PropTypes.array.isRequired,
     onSelectItem: PropTypes.func.isRequired,
     onSearch: PropTypes.func.isRequired,
-    studyCount: PropTypes.number.isRequired,
     currentPage: PropTypes.number,
     rowsPerPage: PropTypes.number,
     studyListDateFilterNumDays: PropTypes.number,
@@ -28,7 +27,8 @@ export default class StudyList extends Component {
       field: PropTypes.string.isRequired,
       order: PropTypes.oneOf(['desc', 'asc']).isRequired
     }),
-    onImport: PropTypes.func
+    onImport: PropTypes.func,
+    pageOptions: PropTypes.array
   };
 
   static defaultProps = {
@@ -256,7 +256,9 @@ export default class StudyList extends Component {
       <div className="StudyList">
         <div className="studyListToolbar clearfix">
           <div className="header pull-left">Study List</div>
-          <div className="studyCount pull-right">{this.props.studyCount}</div>
+          <div className="studyCount pull-right">
+            {this.props.studies.length}
+          </div>
           <div className="pull-right">
             {
               <StudylistToolbar
@@ -436,14 +438,13 @@ export default class StudyList extends Component {
           {this.renderNoMachingResults()}
 
           <PaginationArea
+            pageOptions={this.props.pageOptions}
             currentPage={this.state.searchData.currentPage}
             nextPageFunc={this.nextPage}
             prevPageFunc={this.prevPage}
             onRowsPerPageChange={this.onRowsPerPageChange}
             rowsPerPage={this.state.searchData.rowsPerPage}
-            numberOfPages={Math.ceil(
-              this.props.studyCount / this.state.searchData.rowsPerPage
-            )}
+            recordCount={this.props.studies.length}
           />
         </div>
       </div>

--- a/src/studyList/StudyList.js
+++ b/src/studyList/StudyList.js
@@ -38,8 +38,8 @@ export default class StudyList extends Component {
   };
 
   static DEFAULT_SORTABLE_ICON_CLS = 'fa fa-fw fa-sort';
-  static DESC_SORT_ICON_CLS = 'fa fa-fw fa-sort-desc';
-  static ASC_SORT_ICON_CLS = 'fa fa-fw fa-sort-asc';
+  static DESC_SORT_ICON_CLS = 'fa fa-fw fa-sort-down';
+  static ASC_SORT_ICON_CLS = 'fa fa-fw fa-sort-up';
 
   static studyDatePresets = [
     {

--- a/src/studyList/StudyList.js
+++ b/src/studyList/StudyList.js
@@ -68,7 +68,7 @@ export default class StudyList extends Component {
       patientId: StudyList.DEFAULT_SORTABLE_ICON_CLS,
       accessionNumber: StudyList.DEFAULT_SORTABLE_ICON_CLS,
       studyDatePresets: StudyList.DEFAULT_SORTABLE_ICON_CLS,
-      modality: StudyList.DEFAULT_SORTABLE_ICON_CLS,
+      modalities: StudyList.DEFAULT_SORTABLE_ICON_CLS,
       studyDescription: StudyList.DEFAULT_SORTABLE_ICON_CLS
     };
 
@@ -222,23 +222,23 @@ export default class StudyList extends Component {
   renderTableRow(study) {
     return (
       <tr
-        key={study.studyInstanceUID}
+        key={study.studyInstanceUid}
         className={
-          this.state.highlightedItem === study.studyInstanceUID
+          this.state.highlightedItem === study.studyInstanceUid
             ? 'studylistStudy noselect active'
             : 'studylistStudy noselect'
         }
         onClick={() => {
-          this.onHighlightItem(study.studyInstanceUID);
+          this.onHighlightItem(study.studyInstanceUid);
         }}
         onMouseDown={event => {
           // middle/wheel click
           if (event.button === 1) {
-            this.props.onSelectItem(study.studyInstanceUID);
+            this.props.onSelectItem(study.studyInstanceUid);
           }
         }}
         onDoubleClick={() => {
-          this.props.onSelectItem(study.studyInstanceUID);
+          this.props.onSelectItem(study.studyInstanceUid);
         }}
       >
         <td className="patientName">{study.patientName}</td>
@@ -386,22 +386,22 @@ export default class StudyList extends Component {
                     />
                   </div>
                 </th>
-                <th className="modality">
+                <th className="modalities">
                   <div
-                    id="_modality"
+                    id="_modalities"
                     className="sortingCell"
-                    onClick={this.onSortClick('modality')}
+                    onClick={this.onSortClick('modalities')}
                   >
                     <span>Modality</span>
-                    <i className={this.state.sortClasses.modality}>&nbsp;</i>
+                    <i className={this.state.sortClasses.modalities}>&nbsp;</i>
                   </div>
                   <input
                     type="text"
                     className="form-control studylist-search"
-                    id="modality"
+                    id="modalities"
                     onKeyDown={this.onInputKeydown}
-                    value={this.state.modality}
-                    onChange={this.getChangeHandler('modality')}
+                    value={this.state.modalities}
+                    onChange={this.getChangeHandler('modalities')}
                   />
                 </th>
                 <th className="studyDescription">


### PR DESCRIPTION
- Changing the study list pagination method: once qido does not return the total of studies, I needed to change how paginate it. Now it is doing as OHIF does: checks if the study array size is greater or equals the page size.
- Changing `studyInstanceUID` field to `studyInstanceUid`
- upgrading font-awesome, in order to use the same of ohif-react