### PR TITLE
Measurement table required function

### DIFF
--- a/src/MeasurementTableItem/MeasurementTableItem.js
+++ b/src/MeasurementTableItem/MeasurementTableItem.js
@@ -11,9 +11,9 @@ export default class MeasurementTableItem extends Component {
   static propTypes = {
     measurementData: PropTypes.object.isRequired,
     onItemClick: PropTypes.func.isRequired,
-    onRelabel: PropTypes.func.isRequired,
-    onDelete: PropTypes.func.isRequired,
-    onEditDescription: PropTypes.func.isRequired,
+    onRelabel: PropTypes.func,
+    onDelete: PropTypes.func,
+    onEditDescription: PropTypes.func,
     itemClass: PropTypes.string,
     itemIndex: PropTypes.number
   };


### PR DESCRIPTION
# Changes
- Removing isRequired from onRelabel, editDescription and onDelete as they are now not required. 