### PR TITLE
feat(ThumbnailEntry): Add modality fallback for thumbnails

### DIFF
--- a/src/components/studyBrowser/ThumbnailEntry.js
+++ b/src/components/studyBrowser/ThumbnailEntry.js
@@ -18,6 +18,12 @@ class ThumbnailEntry extends Component {
     error: PropTypes.bool.isRequired,
     active: PropTypes.bool.isRequired,
     stackPercentComplete: PropTypes.number,
+    /**
+    altImageText will be used when no imageId or imageSrc is provided.
+    It will be displayed inside the <div>. This is useful when it is difficult
+    to make a preview for a type of DICOM series (e.g. DICOM-SR)
+    */
+    altImageText: PropTypes.string,
     seriesDescription: PropTypes.string,
     seriesNumber: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     instanceNumber: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -34,13 +40,9 @@ class ThumbnailEntry extends Component {
     });
     const infoOnly = false;
 
-    return (
-      <div
-        className={className}
-        onClick={this.onClick}
-        onDoubleClick={this.onDoubleClick}
-        onMouseDown={this.onMouseDown}
-      >
+    let contents = null;
+    if (this.props.imageSrc || this.props.imageId) {
+      contents = (
         <div className="p-x-1">
           <ImageThumbnail
             imageSrc={this.props.imageSrc}
@@ -49,6 +51,23 @@ class ThumbnailEntry extends Component {
             stackPercentComplete={this.props.stackPercentComplete}
           />
         </div>
+      );
+    } else if (this.props.altImageText) {
+      contents = (
+        <div className={'alt-image-text p-x-1'}>
+          <h1>{this.props.altImageText}</h1>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        className={className}
+        onClick={this.onClick}
+        onDoubleClick={this.onDoubleClick}
+        onMouseDown={this.onMouseDown}
+      >
+        {contents}
         <div
           className={infoOnly ? 'series-details info-only' : 'series-details'}
         >

--- a/src/components/studyBrowser/ThumbnailEntry.styl
+++ b/src/components/studyBrowser/ThumbnailEntry.styl
@@ -9,6 +9,25 @@
   .p-x-1
     padding: 0 1rem
 
+  .alt-image-text
+    align-items: center;
+    justify-content: center;
+    background-color: var(--primary-background-color);
+    box-shadow: inset 0 0 0 1px var(--ui-border-color-dark);
+    border: 5px solid transparent;
+    border-radius: 12px;
+    height: 135px;
+    margin: 0 auto;
+    padding: 5px;
+    position: relative;
+    transition: var(--sidebar-transition);
+    width: 217px;
+    display: flex;
+
+    h1
+      text-align: center
+      color: var(--text-primary-color);
+
   .series-details
     display: flex;
     flex-direction: row;

--- a/src/components/studyBrowser/__docs__/exampleStudies.js
+++ b/src/components/studyBrowser/__docs__/exampleStudies.js
@@ -19,6 +19,12 @@ export const studies = [
         numImageFrames: 256,
         stackPercentComplete: 70,
       },
+      {
+        altImageText: 'SR',
+        seriesDescription: 'Imaging Measurement Report',
+        seriesNumber: '3',
+        stackPercentComplete: 100,
+      },
     ],
   },
   {


### PR DESCRIPTION
Add modality fallback for display sets where no image thumbnail can be displayed.

Updated the example to show an imaginary 'SR' document. 