### PR TITLE
feat(StudyList.js): replacing double click to single click

### DIFF
--- a/src/components/studyList/StudyList.js
+++ b/src/components/studyList/StudyList.js
@@ -213,16 +213,14 @@ class StudyList extends Component {
             ? 'studylistStudy noselect active'
             : 'studylistStudy noselect'
         }
-        onClick={() => {
-          this.onHighlightItem(study.studyInstanceUid);
-        }}
         onMouseDown={event => {
           // middle/wheel click
           if (event.button === 1) {
             this.props.onSelectItem(study.studyInstanceUid);
           }
         }}
-        onDoubleClick={() => {
+        onClick={() => {
+          this.onHighlightItem(study.studyInstanceUid);
           this.props.onSelectItem(study.studyInstanceUid);
         }}
       >


### PR DESCRIPTION
### What
Replacing double click when selecting a study to single click

### Why
There is an opened issue that explains the reason: #506

![singleClick](https://user-images.githubusercontent.com/1713255/58956877-d5d5e900-8775-11e9-91ea-3a7e338f0c09.gif)
