### PR TITLE
fix(exports): Export DropdownMenu instead of Select

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ import {
 import { ICONS, Icon } from './elements';
 
 // Alias this for now as not all dependents are using strict versioning
-import { Select as Dropdown } from './elements/form';
+import { DropdownMenu as Dropdown } from './elements/form';
 import ExpandableToolMenu from './viewer/ExpandableToolMenu.js';
 import LayoutManager from './LayoutChooser/LayoutManager.js';
 import LayoutPanelDropTarget from './LayoutChooser/LayoutPanelDropTarget.js';


### PR DESCRIPTION
OHIF/Viewers was expecting a different component. The one that was exported was breaking the viewer.