### PR TITLE
fix(MeasurementTableItem): Add separators to allow the use of colon

### DIFF
--- a/src/components/measurementTable/MeasurementTableItem.js
+++ b/src/components/measurementTable/MeasurementTableItem.js
@@ -96,7 +96,10 @@ class MeasurementTableItem extends Component {
       >
         <div>
           <div className="measurementLocation">
-            {this.props.t(this.props.measurementData.label)}
+            {this.props.t(this.props.measurementData.label, {
+              keySeparator: '>',
+              nsSeparator: '|',
+            })}
           </div>
           <div>{this.getDataDisplayText()}</div>
           <div className="rowActions">{actionButtons}</div>


### PR DESCRIPTION
When using i18n t function colon is interpreted as separator causing the translation to mismatch.