### PR TITLE
fix(LayoutChooser): Change bootstrap dropdown class to custom

### DIFF
--- a/src/components/layoutButton/LayoutChooser.js
+++ b/src/components/layoutButton/LayoutChooser.js
@@ -90,7 +90,11 @@ class LayoutChooser extends PureComponent {
         columns * this.props.boxSize + (columns + 5) * this.props.cellBorder,
     };
     return (
-      <div className="layoutChooser dropdown-menu" role="menu" style={style}>
+      <div
+        className="layoutChooser layoutChooser-dropdown-menu"
+        role="menu"
+        style={style}
+      >
         <table>
           <tbody>
             {this.state.table.map((row, i) => {

--- a/src/components/layoutButton/LayoutChooser.styl
+++ b/src/components/layoutButton/LayoutChooser.styl
@@ -2,7 +2,7 @@
 
 $borderColor = rgba(77, 99, 110, 0.81)
 
-.dropdown-menu
+.layoutChooser-dropdown-menu
   position: absolute;
   top: 100%;
   left: 0;


### PR DESCRIPTION
After bootstrap removal, when using viewerbase in a project using bootstrap, this class is overriding existent styles, setting `display: none` to dropdowns.