### PR TITLE
fix(ExpandableToolMenu): Update active ExpandableToolMenu toolbutton icon

### DIFF
--- a/src/viewer/ExpandableToolMenu.js
+++ b/src/viewer/ExpandableToolMenu.js
@@ -81,6 +81,17 @@ class ExpandableToolMenu extends React.Component {
     return isActive;
   };
 
+  activeIcon = () => {
+    if (this.props.activeCommand) {
+      return (
+        this.props.buttons.find(btn => this.props.activeCommand === btn.id)
+          .icon || this.props.icon
+      );
+    }
+
+    return this.props.icon;
+  };
+
   onExpandableToolClick = () => {
     if (this.props.onGroupMenuClick) {
       this.props.onGroupMenuClick();
@@ -111,7 +122,7 @@ class ExpandableToolMenu extends React.Component {
           key="menu-button"
           type="tool"
           label={this.props.text}
-          icon={this.props.icon}
+          icon={this.activeIcon()}
           className={'toolbar-button expandableToolMenu'}
           isActive={this.isActive()}
           isExpandable={true}


### PR DESCRIPTION
Update active toolbutton icon on ExpandableToolMenu. 

![Screen Shot 2019-07-05 at 15 01 39](https://user-images.githubusercontent.com/13886933/60738763-d9f05480-9f35-11e9-918e-565538ac061c.png)

Issue created in the project that I'm currently working on: _The target group toolbar icon is constantly ellipsis icon. Instead, it should be dynamically the selected sub tool icon. If no sub tool is selected, then it should be target tool icon by default._
