### PR TITLE
fix(styles): Components without general style classes

### DIFF
--- a/src/components/cineDialog/CineDialog.styl
+++ b/src/components/cineDialog/CineDialog.styl
@@ -1,3 +1,5 @@
+@import './../../design/styles/common/global.styl'
+
 .CineDialog
   background: var(--ui-gray-darkest);
   color: var(--text-secondary-color);

--- a/src/components/layoutButton/LayoutChooser.styl
+++ b/src/components/layoutButton/LayoutChooser.styl
@@ -1,4 +1,5 @@
 @import './../../design/styles/common/button.styl'
+@import './../../design/styles/common/global.styl'
 
 $borderColor = rgba(77, 99, 110, 0.81)
 

--- a/src/components/selectTree/SelectTree.styl
+++ b/src/components/selectTree/SelectTree.styl
@@ -1,3 +1,5 @@
+@import './../../design/styles/common/global.styl'
+
 .selectTreeRoot
   text-align: initial;
   width: 320px;


### PR DESCRIPTION
Some components were using cache style class when running in docz but when cleaning the cache, the missing styles were breaking the layout. So I added the global style import to each component so they can be rendered without this dependency.