### PR TITLE
fix(SelectTree): Fixes onSelected function call

### DIFF
--- a/src/components/selectTree/SelectTree.js
+++ b/src/components/selectTree/SelectTree.js
@@ -176,12 +176,12 @@ export class SelectTree extends Component {
         currentNode: null,
         value: null,
       });
-      return this.props.onSelected(event, item);
     } else {
       this.setState({
         currentNode: item,
       });
     }
+    return this.props.onSelected(event, item);
   };
 
   onBreadcrumbSelected = () => {


### PR DESCRIPTION
When the user clicks in an item in the SelectTree list, the `onSelected` function received in the `props` was being called only when the item is a leaf selected, changed to be called every time because the Viewers select tree doesn't use the leaf selection.

fix #508