### PR TITLE
fix(ToolbarSection): Set label as non required to remove unnecessary w…

### DIFF
--- a/src/components/roundedButtonGroup/RoundedButtonGroup.js
+++ b/src/components/roundedButtonGroup/RoundedButtonGroup.js
@@ -12,7 +12,7 @@ class RoundedButtonGroup extends Component {
     options: PropTypes.arrayOf(
       PropTypes.shape({
         value: PropTypes.any,
-        text: PropTypes.string,
+        label: PropTypes.string,
         icon: PropTypes.oneOfType([
           PropTypes.string,
           PropTypes.shape({
@@ -54,7 +54,7 @@ class RoundedButtonGroup extends Component {
         active: this.props.value === option.value,
       });
 
-      const optionText = option.text && <span>{option.text}</span>;
+      const optionText = option.label && <span>{option.label}</span>;
       const iconProps =
         typeof option.icon === 'string' ? { name: option.icon } : option.icon;
 

--- a/src/components/toolbarSection/ToolbarSection.js
+++ b/src/components/toolbarSection/ToolbarSection.js
@@ -16,8 +16,7 @@ class ToolbarSection extends PureComponent {
     buttons: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string,
-        label: PropTypes.string /** If it's a button */,
-        text: PropTypes.string /** If it's a group */,
+        label: PropTypes.string,
         icon: PropTypes.oneOfType([
           PropTypes.string,
           PropTypes.shape({

--- a/src/components/toolbarSection/ToolbarSection.js
+++ b/src/components/toolbarSection/ToolbarSection.js
@@ -16,7 +16,7 @@ class ToolbarSection extends PureComponent {
     buttons: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string,
-        label: PropTypes.string,
+        label: PropTypes.string.isRequired,
         icon: PropTypes.oneOfType([
           PropTypes.string,
           PropTypes.shape({

--- a/src/components/toolbarSection/ToolbarSection.js
+++ b/src/components/toolbarSection/ToolbarSection.js
@@ -16,7 +16,8 @@ class ToolbarSection extends PureComponent {
     buttons: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string,
-        label: PropTypes.string.isRequired,
+        label: PropTypes.string /** If it's a button */,
+        text: PropTypes.string /** If it's a group */,
         icon: PropTypes.oneOfType([
           PropTypes.string,
           PropTypes.shape({

--- a/src/viewer/ExpandableToolMenu.js
+++ b/src/viewer/ExpandableToolMenu.js
@@ -8,8 +8,8 @@ import { Tooltip } from '../components/tooltip';
 
 class ExpandableToolMenu extends React.Component {
   static propTypes = {
-    /** Button label/text */
-    text: PropTypes.string.isRequired,
+    /** Button label */
+    label: PropTypes.string.isRequired,
     /** Array of buttons to render when expanded */
     buttons: PropTypes.arrayOf(
       PropTypes.shape({
@@ -36,7 +36,7 @@ class ExpandableToolMenu extends React.Component {
   static defaultProps = {
     buttons: [],
     icon: 'ellipse-circle',
-    text: 'More',
+    label: 'More',
   };
 
   constructor(props) {
@@ -121,7 +121,7 @@ class ExpandableToolMenu extends React.Component {
         <ToolbarButton
           key="menu-button"
           type="tool"
-          label={this.props.text}
+          label={this.props.label}
           icon={this.activeIcon()}
           className={'toolbar-button expandableToolMenu'}
           isActive={this.isActive()}

--- a/src/viewer/PresetToggle.js
+++ b/src/viewer/PresetToggle.js
@@ -14,7 +14,7 @@ export default class PresetToggle extends Component {
   static propTypes = {
     buttons: PropTypes.arrayOf(
       PropTypes.shape({
-        text: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
         icon: PropTypes.oneOfType([
           PropTypes.string,
           PropTypes.shape({
@@ -62,7 +62,7 @@ export default class PresetToggle extends Component {
         <div className="tools">{toolItems}</div>
         <span className="presetSelected">
           LEVELS:
-          {selectedButton ? selectedButton.text : 'Manual'}
+          {selectedButton ? selectedButton.label : 'Manual'}
         </span>
       </div>
     );

--- a/src/viewer/ToolbarButton.js
+++ b/src/viewer/ToolbarButton.js
@@ -37,7 +37,7 @@ export function ToolbarButton(props) {
 ToolbarButton.propTypes = {
   id: PropTypes.string,
   isActive: PropTypes.bool,
-  /** Display text/label for button */
+  /** Display label for button */
   label: PropTypes.string.isRequired,
   /** Alternative text to show when button is active */
   labelWhenActive: PropTypes.string,


### PR DESCRIPTION
Avoid unnecessary warning when a button is a group. When its group the ExpandableMenu expects text instead of label.

![Screen Shot 2019-07-11 at 18 53 04](https://user-images.githubusercontent.com/13886933/61087885-4a531600-a40d-11e9-8e8e-5dec7c157a81.png)
