### PR TITLE
fix(PaginationArea.js PaginationArea.styl): fixing next/prev button on Safari

### DIFF
--- a/src/components/studyList/PaginationArea.js
+++ b/src/components/studyList/PaginationArea.js
@@ -36,7 +36,7 @@ class PaginationArea extends PureComponent {
     return (
       <div className="col-xs-8 col-sm-9 col-md-9">
         <div className="form-inline form-group page-buttons noselect">
-          <label>
+          <React.Fragment>
             <ul className="pagination-control no-margins">
               <li className="page-item prev">
                 <button
@@ -60,7 +60,7 @@ class PaginationArea extends PureComponent {
                 </button>
               </li>
             </ul>
-          </label>
+          </React.Fragment>
         </div>
       </div>
     );

--- a/src/components/studyList/PaginationArea.styl
+++ b/src/components/studyList/PaginationArea.styl
@@ -22,30 +22,27 @@
   .page-buttons
     margin: 0
     text-align: right
+    font-weight: normal
+    ul.pagination-control
+      margin: 0
 
-    label
-      font-weight: normal
+      li
+        display: table-cell
+        padding: 5px 2px
 
-      ul.pagination-control
-        margin: 0
+        button
+          padding: 4px 8px
+          background-color: var(--primary-background-color)
+          border-color: var(--ui-gray)
+          color: var(--ui-gray-darkest)
+          color: white
+          text-decoration: none
 
-        li
-          display: table-cell
-          padding: 5px 2px
+          &:hover:enabled
+            color: var(--active-color)
 
+        .active
           button
-            padding: 4px 8px
-            background-color: var(--primary-background-color)
-            border-color: var(--ui-gray)
-            color: var(--ui-gray-darkest)
+            background-color: var(--ui-gray)
+            border-color: #ddd
             color: white
-            text-decoration: none
-
-            &:hover:enabled
-              color: var(--active-color)
-
-          .active
-            button
-              background-color: var(--ui-gray)
-              border-color: #ddd
-              color: white


### PR DESCRIPTION
This PR is related to the issue https://github.com/OHIF/Viewers/issues/670

